### PR TITLE
use Authorization header instead of query parameter for oauth type

### DIFF
--- a/index.js
+++ b/index.js
@@ -638,8 +638,9 @@ var Client = module.exports = function(config) {
             var basic;
             switch (this.auth.type) {
                 case "oauth":
-                    path += (path.indexOf("?") === -1 ? "?" : "&") +
-                        "access_token=" + encodeURIComponent(this.auth.token);
+                    headers.authorization = " token " + this.auth.token;
+                    //path += (path.indexOf("?") === -1 ? "?" : "&") +
+                    //    "access_token=" + encodeURIComponent(this.auth.token);
                     break;
                 case "token":
                     basic = new Buffer(this.auth.username + "/token:" + this.auth.token, "ascii").toString("base64");


### PR DESCRIPTION
see ticket 18155

and 

```
On August 16th, 2021 at 19:13 (UTC) your personal access token (*****_devqa) using NodeJS HTTP Client was used as part of a query parameter to access an endpoint through the GitHub API:
```